### PR TITLE
Add package-upgrade action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -2,3 +2,6 @@ openstack-upgrade:
   description: |
     Perform openstack upgrades. Config option action-managed-upgrade must be
     set to True.
+package-upgrade:
+  description: |
+    Perform package upgrades for the current OpenStack release.

--- a/actions/os_principle_actions.py
+++ b/actions/os_principle_actions.py
@@ -31,9 +31,21 @@ charms_openstack.bus.discover()
 
 
 def openstack_upgrade_action(*args):
-    """Run the resume action."""
+    """Run the openstack-upgrade action."""
     with charms_openstack.charm.provide_charm_instance() as charm_instance:
-        charm_instance.run_upgrade()
+        charm_instance.run_upgrade(upgrade_openstack=True)
+        charm_instance._assess_status()
+
+def package_upgrade_action(*args):
+    """Run the package-upgrade action."""
+    with charms_openstack.charm.provide_charm_instance() as charm_instance:
+        if charm_instance.openstack_upgrade_available(
+                charm_instance.release_pkg):
+            hookenv.action_set({'outcome':
+                                'upgrade skipped because an openstack upgrade '
+                                'is available'})
+            return
+        charm_instance.run_upgrade(upgrade_openstack=False)
         charm_instance._assess_status()
 
 
@@ -41,6 +53,7 @@ def openstack_upgrade_action(*args):
 # can map to a python function.
 ACTIONS = {
     "openstack-upgrade": openstack_upgrade_action,
+    "package-upgrade": package_upgrade_action,
 }
 
 

--- a/actions/package-upgrade
+++ b/actions/package-upgrade
@@ -1,0 +1,1 @@
+os_principle_actions.py


### PR DESCRIPTION
The package-upgrade action is similar to the openstack-upgrade
action except that it performs package upgrades within the current
openstack release. If a new openstack release is available, the
package-upgrade action will not perform any upgrades.